### PR TITLE
Various snap fixes

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,30 +1,37 @@
 name: shotwell
-version: '0.32.1'
-summary: Open source photo manager for GNOME
-description: |
-  Shotwell is an open source photo manager for GNOME. It allows you to import,
-  organize, edit, and share your photos.
-
+adopt-info: shotwell
 grade: stable
 confinement: strict
-
 base: core22
-adopt-info: shotwell
+
+slots:
+  # for GtkApplication registration
+  drawing:
+    interface: dbus
+    bus: session
+    name: org.gnome.Shotwell
 
 apps:
   shotwell:
-    command: usr/local/bin/shotwell
+    command: usr/bin/shotwell
     extensions: [gnome]
-    desktop: usr/local/share/applications/org.gnome.Shotwell.desktop
+    desktop: usr/share/applications/org.gnome.Shotwell.desktop
     environment:
-      LD_LIBRARY_PATH: "$SNAP/usr/local/lib/x86_64-linux-gnu:\
-        $SNAP/usr/lib/x86_64-linux-gnu"
+      HOME: $SNAP_USER_COMMON
+    plugs:
+      - audio-playback
+      - home
+      - mount-observe
+      - hardware-observe
 
 parts:
   shotwell:
     plugin: meson
     source: https://gitlab.gnome.org/GNOME/shotwell.git
-    source-tag: shotwell-$SNAPCRAFT_PROJECT_VERSION
+    source-tag: shotwell-0.32.1
+    meson-parameters:
+      - --prefix=/usr
+    parse-info: [ usr/share/metainfo/org.gnome.Shotwell.appdata.xml ]
     build-packages:
       - cmake
       - libgstreamer1.0-dev
@@ -32,11 +39,6 @@ parts:
       - libgphoto2-dev
       - libgexiv2-dev
       - libraw-dev
-    override-build: |
-      DESKTOP=$CRAFT_PART_INSTALL/usr/local/share/applications/org.gnome.Shotwell.desktop
-      EXEC=/snap/shotwell/current/usr/local/bin/shotwell
-      craftctl default
-      sed -i "s:Exec=shotwell:Exec=$EXEC:g" $DESKTOP
     stage-packages:
       - libexif12
       - libgcr-ui-3-1
@@ -47,6 +49,3 @@ parts:
       - libgstreamer-plugins-base1.0-0
       - libgudev-1.0-0
       - libraw20
-      - shotwell-common
-      - dconf-cli
-      - default-dbus-session-bus

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,7 +6,7 @@ base: core22
 
 slots:
   # for GtkApplication registration
-  drawing:
+  shotwell:
     interface: dbus
     bus: session
     name: org.gnome.Shotwell

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -47,3 +47,22 @@ parts:
       - libgphoto2-6
       - libgphoto2-port12
       - libraw20
+  cleanup:
+    after: [shotwell]
+    plugin: nil
+    build-snaps: [core22, gtk-common-themes]
+    override-prime: |
+      set -eux
+      for snap in "core22" "gtk-common-themes"; do
+        cd "/snap/$snap/current" && find . -type f,l -name *.so.* -exec rm -f "$CRAFT_PRIME/{}" \;
+      done
+      for snap in "core22"; do
+        cd "/snap/$snap/current/usr/lib"
+        for filename in [ *.so* ]; do
+          rm -f "$CRAFT_PRIME/usr/lib/$CRAFT_ARCH_TRIPLET/$filename"
+        done
+        cd "/snap/$snap/current/usr/lib/$CRAFT_ARCH_TRIPLET"
+        for filename in [ *.so* ]; do
+          rm -f "$CRAFT_PRIME/usr/lib/$filename"
+        done
+      done

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,7 +31,7 @@ parts:
     source-tag: shotwell-0.32.1
     meson-parameters:
       - --prefix=/usr
-    parse-info: [ usr/share/metainfo/org.gnome.Shotwell.appdata.xml ]
+    parse-info: [usr/share/metainfo/org.gnome.Shotwell.appdata.xml]
     build-packages:
       - cmake
       - libgstreamer1.0-dev
@@ -54,7 +54,8 @@ parts:
     override-prime: |
       set -eux
       for snap in "core22" "gtk-common-themes"; do
-        cd "/snap/$snap/current" && find . -type f,l -name *.so.* -exec rm -f "$CRAFT_PRIME/{}" \;
+        cd "/snap/$snap/current" && find . -type f,l -name *.so.* \
+          -exec rm -f "$CRAFT_PRIME/{}" \;
       done
       for snap in "core22"; do
         cd "/snap/$snap/current/usr/lib"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -46,6 +46,4 @@ parts:
       - libgexiv2-2
       - libgphoto2-6
       - libgphoto2-port12
-      - libgstreamer-plugins-base1.0-0
-      - libgudev-1.0-0
       - libraw20

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -9,8 +9,11 @@ def test_install():
         snapcraft = yaml.safe_load(file)
 
         subprocess.run(
-            f"sudo snap install ./{snapcraft['name']}_{snapcraft['version']}_amd64.snap --devmode".split(),
+            f"sudo snap install ./{snapcraft['name']}_*_amd64.snap --devmode",
             check=True,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
         )
 
 
@@ -21,13 +24,17 @@ def test_all_apps():
 
         override = {}
 
-        skip = ["shotwell"]
+        skip = []
 
         for app, data in snapcraft["apps"].items():
             if not bool(data.get("daemon")) and app not in skip:
-                print(f"Testing {snapcraft['name']}.{app}....")
+                command = (
+                    app if snapcraft["name"] == app else f"{snapcraft['name']}.{app}"
+                )
+
+                print(f"Testing {command}....")
                 subprocess.run(
-                    f"{snapcraft['name']}.{app} {override.get(app, '--help')}".split(),
+                    f"{command} {override.get(app, '--help')}".split(),
                     check=True,
                 )
 


### PR DESCRIPTION
 - Use appstream meta data
 - Specify prefix
 - Added necessary plugs
 - Define dbus slot
 - Dropped unused stage-packages
 - Set HOME to SNAP_USER_COMMON to avoid versioned runtime data
