### PR TITLE
Added removable-media plug fixes #2

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,6 +23,7 @@ apps:
       - home
       - mount-observe
       - hardware-observe
+      - removable-media
 
 parts:
   shotwell:


### PR DESCRIPTION
Connecting removable-media allows access to camera's and other storage devices