### PR TITLE
Added use of .desktop that opens image files

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -37,7 +37,13 @@ apps:
     desktop: usr/share/applications/org.gnome.Shotwell-Viewer.desktop
     environment:
       HOME: $SNAP_USER_COMMON
-    plugs: *pluglist
+    plugs:
+      - audio-playback
+      - home
+      - raw-usb
+      - mount-observe
+      - hardware-observe
+      - removable-media
 
 parts:
   scripts:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,7 +24,7 @@ apps:
     desktop: usr/share/applications/org.gnome.Shotwell.desktop
     environment:
       HOME: $SNAP_USER_COMMON
-    plugs:
+    plugs: &pluglist
       - audio-playback
       - home
       - raw-usb

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -37,13 +37,7 @@ apps:
     desktop: usr/share/applications/org.gnome.Shotwell-Viewer.desktop
     environment:
       HOME: $SNAP_USER_COMMON
-    plugs:
-      - audio-playback
-      - home
-      - raw-usb
-      - mount-observe
-      - hardware-observe
-      - removable-media
+    plugs: *pluglist
 
 parts:
   scripts:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,6 +31,19 @@ apps:
       - mount-observe
       - hardware-observe
       - removable-media
+  shotwell-viewer:
+    command: launch.sh $SNAP/usr/bin/shotwell
+    extensions: [gnome]
+    desktop: usr/share/applications/org.gnome.Shotwell-Viewer.desktop
+    environment:
+      HOME: $SNAP_USER_COMMON
+    plugs:
+      - audio-playback
+      - home
+      - raw-usb
+      - mount-observe
+      - hardware-observe
+      - removable-media
 
 parts:
   scripts:


### PR DESCRIPTION
# Pull Request Template

## Description

This fixes the issue of Shotwell not appearing as an option in the file manager.

I'm talking about the .desktop file specifically for opening files, which appears automatically in the deb version, including as an option in the "default applications" section.

## Type of change

Please check only the options that are relevant.

- [ ] General Maintenance
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I tested it in the Nemo file manager, right-clicking on image files and selecting "open with."

I also went into Budgie settings to check if Shotwell was listed as one of the default application options.

**Test Configuration**:

* OS (please include version): Ubuntu Budgie 25.04
* Any other relevant environment information:

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings

